### PR TITLE
Add all primitive operator tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ gradle-app.setting
 *.iml
 *.ipr
 *.iws
+
+api/out
+cli/out
+client/out

--- a/api/src/test/java/org/iconic/ea/operator/primitive/AdditionTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/AdditionTest.java
@@ -11,31 +11,33 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AdditionTest {
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Addition}
+ * @author Jasbir Shah
+ */
+class AdditionTest {
     @DisplayName("Test addition using doubles")
     @MethodSource("doubleListProvider")
     @ParameterizedTest
     void addDoublesTest(final List<Double> args, final double expected) {
         final FunctionalPrimitive<Double, Double> add = new Addition();
-        final double delta = 0.001d;
+        final double delta = 0.001;
         final double actual = add.apply(args);
 
         assertEquals(expected, actual, delta);
     }
 
     /**
-     * <p>
-     * Returns a stream of double n-tuples, where the last member of the tuple is the sum of all the preceeding
-     * members
-     * </p>
+     * <p>Returns a stream of double n-tuples, where the last member of the tuple is the sum of all the preceeding
+     * members</p>
      *
      * @return a stream of double n-tuples
      */
     private static Stream<Arguments> doubleListProvider() {
         return Stream.of(
-                Arguments.of(Arrays.asList(1.d, -1.d), 0.d),
-                Arguments.of(Arrays.asList(0.d, -1.d), -1.d),
-                Arguments.of(Arrays.asList(0.d, 1.d), 1.d)
+                Arguments.of(Arrays.asList(1.0, -1.0), 0.0),
+                Arguments.of(Arrays.asList(0.0, -1.0), -1.0),
+                Arguments.of(Arrays.asList(0.0, 1.0), 1.0)
         );
     }
 }

--- a/api/src/test/java/org/iconic/ea/operator/primitive/ConstantTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/ConstantTest.java
@@ -1,0 +1,41 @@
+package org.iconic.ea.operator.primitive;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Constant}
+ * @author Scott Walker
+ */
+class ConstantTest {
+    @DisplayName("Test constants using doubles")
+    @MethodSource("doubleListProvider")
+    @ParameterizedTest
+    void constantDoublesTest(final double arg, final double expected) {
+        final FunctionalPrimitive<Double, Double> constant = new Constant<>(arg);
+        final double delta = 0.001;
+        final double actual = constant.apply(new ArrayList<>());
+
+        assertEquals(expected, actual, delta);
+    }
+
+    /**
+     * <p>Returns a stream of two identical doubles</p>
+     *
+     * @return a stream of double n-tuples
+     */
+    private static Stream<Arguments> doubleListProvider() {
+        return Stream.of(
+                Arguments.of(1.0, 1.0),
+                Arguments.of(0.0, 0.0),
+                Arguments.of(10.0, 10.0)
+        );
+    }
+}

--- a/api/src/test/java/org/iconic/ea/operator/primitive/CosTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/CosTest.java
@@ -1,0 +1,49 @@
+package org.iconic.ea.operator.primitive;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Cos}
+ * @author Scott Walker
+ */
+class CosTest {
+
+    /** Hard-coded value of pi for testing purposes */
+    private static final double PI = 3.14159;
+
+    @DisplayName("Test cosine using doubles")
+    @MethodSource("doubleListProvider")
+    @ParameterizedTest
+    void cosDoublesTest(final List<Double> args, final double expected) {
+        final FunctionalPrimitive<Double, Double> cos = new Cos();
+        final double delta = 0.001;
+        final double actual = cos.apply(args);
+
+        assertEquals(expected, actual, delta);
+    }
+
+    /**
+     * <p>Returns a stream of double n-tuples, where the last number cos of the first</p>
+     *
+     * @return a stream of double n-tuples
+     */
+    private static Stream<Arguments> doubleListProvider() {
+        return Stream.of(
+                Arguments.of(Arrays.asList(0.0), 1.0),
+                Arguments.of(Arrays.asList(PI/2), 0.0),
+                Arguments.of(Arrays.asList(PI), -1.0),
+                Arguments.of(Arrays.asList(-PI/2), 0.0),
+                Arguments.of(Arrays.asList(PI/4), 0.70711),
+                Arguments.of(Arrays.asList(-PI/4), 0.70711)
+        );
+    }
+}

--- a/api/src/test/java/org/iconic/ea/operator/primitive/DivisionTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/DivisionTest.java
@@ -11,33 +11,36 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DivisionTest {
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Division}
+ * @author Jasbir Shah
+ */
+class DivisionTest {
     @DisplayName("Test division using doubles")
     @MethodSource("doubleListProvider")
     @ParameterizedTest
     void divideDoublesTest(final List<Double> args, final double expected) {
         final FunctionalPrimitive<Double, Double> division = new Division();
-        final double delta = 0.001d;
+        final double delta = 0.001;
         final double actual = division.apply(args);
 
         assertEquals(expected, actual, delta);
     }
 
     /**
-     * <p>
-     * Returns a stream of double n-tuples, where the last member of the tuple is the sum of all the preceeding
-     * members
-     * </p>
+     * <p>Returns a stream of double n-tuples, where the last member is the result of dividing
+     * the first by the second</p>
      *
      * @return a stream of double n-tuples
      */
     private static Stream<Arguments> doubleListProvider() {
         return Stream.of(
-                Arguments.of(Arrays.asList(1.d, 1.d), 1.d),
-                Arguments.of(Arrays.asList(1.d, -1.d), -1.d),
-                Arguments.of(Arrays.asList(0.d, -1.d), 0.d),
-                Arguments.of(Arrays.asList(0.d, 1.d), 0.d),
-                Arguments.of(Arrays.asList(1.d, 0.d), 1.d)
+                Arguments.of(Arrays.asList(1.0, 1.0), 1.0),
+                Arguments.of(Arrays.asList(1.0, -1.0), -1.0),
+                Arguments.of(Arrays.asList(0.0, -1.0), 0.0),
+                Arguments.of(Arrays.asList(0.0, 1.0), 0.0),
+                Arguments.of(Arrays.asList(1.0, 0.0), 1.0),
+                Arguments.of(Arrays.asList(1024.0, 512.0), 2.0)
         );
     }
 }

--- a/api/src/test/java/org/iconic/ea/operator/primitive/MultiplicationTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/MultiplicationTest.java
@@ -11,32 +11,35 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MultiplicationTest {
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Multiplication}
+ * @author Jasbir Shah
+ */
+class MultiplicationTest {
     @DisplayName("Test multiplication using doubles")
     @MethodSource("doubleListProvider")
     @ParameterizedTest
     void multiplyDoublesTest(final List<Double> args, final double expected) {
         final FunctionalPrimitive<Double, Double> multiplication = new Multiplication();
-        final double delta = 0.001d;
+        final double delta = 0.001;
         final double actual = multiplication.apply(args);
 
         assertEquals(expected, actual, delta);
     }
 
     /**
-     * <p>
-     * Returns a stream of double n-tuples, where the last member of the tuple is the sum of all the preceeding
-     * members
-     * </p>
+     * <p>Returns a stream of double n-tuples, where the last member is the multiplication
+     * of the first two</p>
      *
      * @return a stream of double n-tuples
      */
     private static Stream<Arguments> doubleListProvider() {
         return Stream.of(
-                Arguments.of(Arrays.asList(1.d, 1.d), 1.d),
-                Arguments.of(Arrays.asList(1.d, -1.d), -1.d),
-                Arguments.of(Arrays.asList(0.d, -1.d), 0.d),
-                Arguments.of(Arrays.asList(0.d, 1.d), 0.d)
+                Arguments.of(Arrays.asList(1.0, 1.0), 1.0),
+                Arguments.of(Arrays.asList(1.0, -1.0), -1.0),
+                Arguments.of(Arrays.asList(0.0, -1.0), 0.0),
+                Arguments.of(Arrays.asList(0.0, 1.0), 0.0),
+                Arguments.of(Arrays.asList(32.0, 32.0), 1024.0)
         );
     }
 }

--- a/api/src/test/java/org/iconic/ea/operator/primitive/PowerTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/PowerTest.java
@@ -1,0 +1,47 @@
+package org.iconic.ea.operator.primitive;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Power}
+ * @author Scott Walker
+ */
+class PowerTest {
+    @DisplayName("Test powers using doubles")
+    @MethodSource("doubleListProvider")
+    @ParameterizedTest
+    void powerDoublesTest(final List<Double> args, final double expected) {
+        final FunctionalPrimitive<Double, Double> power = new Power();
+        final double delta = 0.001;
+        final double actual = power.apply(args);
+
+        assertEquals(expected, actual, delta);
+    }
+
+    /**
+     * <p>Returns a stream of double n-tuples, where the last number is the first raised to the power
+     * of the second</p>
+     *
+     * @return a stream of double n-tuples
+     */
+    private static Stream<Arguments> doubleListProvider() {
+        return Stream.of(
+                Arguments.of(Arrays.asList(1.0, 1.0), 1.0),
+                Arguments.of(Arrays.asList(100.0, 0.0), 1.0),
+                Arguments.of(Arrays.asList(2.0, 2.0), 4.0),
+                Arguments.of(Arrays.asList(32.0, 2.0), 1024.0),
+                Arguments.of(Arrays.asList(10.0, 4.0), 10000.0),
+                Arguments.of(Arrays.asList(-2.0, 2.0), 4.0),
+                Arguments.of(Arrays.asList(-2.0, 3.0), -8.0)
+        );
+    }
+}

--- a/api/src/test/java/org/iconic/ea/operator/primitive/RootTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/RootTest.java
@@ -1,0 +1,47 @@
+package org.iconic.ea.operator.primitive;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Root}
+ * @author Scott Walker
+ */
+class RootTest {
+    @DisplayName("Test root using doubles")
+    @MethodSource("doubleListProvider")
+    @ParameterizedTest
+    void rootDoublesTest(final List<Double> args, final double expected) {
+        final FunctionalPrimitive<Double, Double> root = new Root();
+        final double delta = 0.001;
+        final double actual = root.apply(args);
+
+        assertEquals(expected, actual, delta);
+    }
+
+    /**
+     * <p>Returns a stream of double n-tuples, where the last number is the first raised to the inverse power
+     * of the second (the nth root)</p>
+     *
+     * @return a stream of double n-tuples
+     */
+    private static Stream<Arguments> doubleListProvider() {
+        return Stream.of(
+                Arguments.of(Arrays.asList(1.0, 1.0), 1.0),
+                Arguments.of(Arrays.asList(100.0, 1.0), 100.0),
+                Arguments.of(Arrays.asList(4.0, 2.0), 2.0),
+                Arguments.of(Arrays.asList(1024.0, 2.0), 32.0),
+                Arguments.of(Arrays.asList(1024.0, 10.0), 2.0),
+                Arguments.of(Arrays.asList(-8.0, 3.0), -2.0),
+                Arguments.of(Arrays.asList(8.0, -3.0), 0.5)
+        );
+    }
+}

--- a/api/src/test/java/org/iconic/ea/operator/primitive/SinTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/SinTest.java
@@ -1,0 +1,49 @@
+package org.iconic.ea.operator.primitive;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Sin}
+ * @author Scott Walker
+ */
+class SinTest {
+
+    /** Hard-coded value of pi for testing purposes */
+    private static final double PI = 3.14159;
+
+    @DisplayName("Test sine using doubles")
+    @MethodSource("doubleListProvider")
+    @ParameterizedTest
+    void sinDoublesTest(final List<Double> args, final double expected) {
+        final FunctionalPrimitive<Double, Double> sin = new Sin();
+        final double delta = 0.001;
+        final double actual = sin.apply(args);
+
+        assertEquals(expected, actual, delta);
+    }
+
+    /**
+     * <p>Returns a stream of double n-tuples, where the last number sin of the first</p>
+     *
+     * @return a stream of double n-tuples
+     */
+    private static Stream<Arguments> doubleListProvider() {
+        return Stream.of(
+                Arguments.of(Arrays.asList(0.0), 0.0),
+                Arguments.of(Arrays.asList(PI/2), 1.0),
+                Arguments.of(Arrays.asList(PI), 0.0),
+                Arguments.of(Arrays.asList(-PI/2), -1.0),
+                Arguments.of(Arrays.asList(PI/4), 0.70711),
+                Arguments.of(Arrays.asList(-PI/4), -0.70711)
+        );
+    }
+}

--- a/api/src/test/java/org/iconic/ea/operator/primitive/SubtractionTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/SubtractionTest.java
@@ -11,33 +11,36 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SubtractionTest {
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Subtraction}
+ * @author Jasbir Shah
+ */
+class SubtractionTest {
     @DisplayName("Test subtraction using doubles")
     @MethodSource("doubleListProvider")
     @ParameterizedTest
     void subtractDoublesTest(final List<Double> args, final double expected) {
         final FunctionalPrimitive<Double, Double> subtract = new Subtraction();
-        final double delta = 0.001d;
+        final double delta = 0.001;
         final double actual = subtract.apply(args);
 
         assertEquals(expected, actual, delta);
     }
 
     /**
-     * <p>
-     * Returns a stream of double n-tuples, where the last member of the tuple is the sum of all the preceeding
-     * members
-     * </p>
+     * <p>Returns a stream of double n-tuples, where the last member is the subraction of
+     * all numbers in the list (a - b - c - d - ...)</p>
      *
      * @return a stream of double n-tuples
      */
     private static Stream<Arguments> doubleListProvider() {
         return Stream.of(
-                Arguments.of(Arrays.asList(1.d, 1.d), 0.d),
-                Arguments.of(Arrays.asList(1.d, -1.d), 2.d),
-                Arguments.of(Arrays.asList(0.d, -1.d), 1.d),
-                Arguments.of(Arrays.asList(0.d, 1.d), -1.d),
-                Arguments.of(Arrays.asList(87.d, 27.d, 9.8d, 4.d, 28.d, 93.d, 92.d, 63.d, 55.d, 30.d, -105.3d), -209.5d)
+                Arguments.of(Arrays.asList(1.0, 1.0), 0.0),
+                Arguments.of(Arrays.asList(1.0, -1.0), 2.0),
+                Arguments.of(Arrays.asList(0.0, -1.0), 1.0),
+                Arguments.of(Arrays.asList(0.0, 1.0), -1.0),
+                Arguments.of(Arrays.asList(87.0, 27.0, 9.8, 4.0, 28.0, 93.0, 92.0, 63.0, 55.0, 30.0, -105.3), -209.5d),
+                Arguments.of(Arrays.asList(10.0, 1.0, 2.0, 3.0, 4.0), 0.0)
         );
     }
 }

--- a/api/src/test/java/org/iconic/ea/operator/primitive/TanTest.java
+++ b/api/src/test/java/org/iconic/ea/operator/primitive/TanTest.java
@@ -1,0 +1,48 @@
+package org.iconic.ea.operator.primitive;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for {@link org.iconic.ea.operator.primitive.Tan}
+ * @author Scott Walker
+ */
+class TanTest {
+
+    /** Hard-coded value of pi for testing purposes */
+    private static final double PI = 3.14159;
+
+    @DisplayName("Test tan using doubles")
+    @MethodSource("doubleListProvider")
+    @ParameterizedTest
+    void tanDoublesTest(final List<Double> args, final double expected) {
+        final FunctionalPrimitive<Double, Double> tan = new Tan();
+        final double delta = 0.001;
+        final double actual = tan.apply(args);
+
+        assertEquals(expected, actual, delta);
+    }
+
+    /**
+     * <p>Returns a stream of double n-tuples, where the last number tan of the first</p>
+     *
+     * @return a stream of double n-tuples
+     */
+    private static Stream<Arguments> doubleListProvider() {
+        return Stream.of(
+                Arguments.of(Arrays.asList(0.0), 0.0),
+                Arguments.of(Arrays.asList(PI), 0.0),
+                Arguments.of(Arrays.asList(PI/4), 1.0),
+                Arguments.of(Arrays.asList(-PI/4), -1.0),
+                Arguments.of(Arrays.asList(PI/3), 1.73205)
+        );
+    }
+}


### PR DESCRIPTION
**Changes**
Add remaining tests for the primitives. RootTest current fails as the implementation is wrong.