### PR TITLE
Default funky funk works from get go

### DIFF
--- a/client/src/main/java/org/iconic/project/definition/DefineSearchController.java
+++ b/client/src/main/java/org/iconic/project/definition/DefineSearchController.java
@@ -150,6 +150,7 @@ public class DefineSearchController implements Initializable, DefineSearchServic
             // NOTE(Meyer): Must check if not null otherwise injection will cause an NPE (it's dumb, I know)
             if (tfTargetExpression != null) {
                 tfTargetExpression.setText(functionStr);
+                dataset.get().defineFunction(functionStr);
             }
         }
     }


### PR DESCRIPTION
If function definition text field wasn't clicked, all the features in the set would be used - meaning that the searching would end pretty quick as y = y would be the best fit.

**Changes**

_Client_
When new dataset is loaded in, the function will be generated and parsed immediately so that all features are properly used/discriminated.
