### PR TITLE
Feature/smoothing window

### DIFF
--- a/client/src/main/java/org/iconic/project/processing/ProcessDataController.java
+++ b/client/src/main/java/org/iconic/project/processing/ProcessDataController.java
@@ -75,7 +75,7 @@ public class ProcessDataController implements Initializable {
     @FXML
     private ComboBox<String> cbHandleMissingValuesOptions;
     @FXML
-    private TextField tfNormaliseMin, tfNormaliseMax, tfOffsetValue;
+    private TextField tfSmoothingWindow, tfNormaliseMin, tfNormaliseMax, tfOffsetValue;
 
     /**
      * <p>
@@ -125,6 +125,11 @@ public class ProcessDataController implements Initializable {
         addCheckBoxChangeListener(cbOffset, vbOffset);
 
         addComboBoxChangeListener(cbHandleMissingValuesOptions, cbHandleMissingValues);
+
+        addTextFieldChangeListener(tfSmoothingWindow, false);
+        addTextFieldChangeListener(tfNormaliseMin, true);
+        addTextFieldChangeListener(tfNormaliseMax, true);
+        addTextFieldChangeListener(tfOffsetValue, true);
     }
 
     /**
@@ -198,6 +203,30 @@ public class ProcessDataController implements Initializable {
                     convertTransformTypeToFunction(convertCheckBoxToTransformType(checkbox));
 
                     updateModifiedText(selectedIndex, selectedHeader);
+                }
+            }
+        });
+    }
+
+    /**
+     * Adds a change listener to a specified TextField which strips out all non-numerical characters to ensure
+     * that the field only contains integer values.
+     *
+     * @param textField The selected TextField
+     * @param allowDecimals A boolean flag denoting whether or not to allow decimal points in the TextField
+     */
+    private void addTextFieldChangeListener(TextField textField, Boolean allowDecimals) {
+        textField.textProperty().addListener(new ChangeListener<String>() {
+            @Override
+            public void changed(ObservableValue<? extends String> observable, String oldValue, String newValue) {
+                if (allowDecimals) {
+                    if (!newValue.matches("\\d*(\\.\\d*)?")) {
+                        textField.setText(oldValue);
+                    }
+                } else {
+                    if (!newValue.matches("\\d*")) {
+                        textField.setText(newValue.replaceAll("[^\\d]", ""));
+                    }
                 }
             }
         });
@@ -278,8 +307,11 @@ public class ProcessDataController implements Initializable {
             Optional<DataManager<Double>> dataManager = getDataManager();
 
             if (cbSmoothData.isSelected() && dataManager.isPresent()) {
+                int smoothingWindow = Integer.parseInt(tfSmoothingWindow.getText());
+
                 Smooth smooth = new Smooth();
                 smooth.setTransformType(TransformType.Smoothed);
+                smooth.setNeighbourSize(smoothingWindow);
 
                 addNewPreprocessor(dataManager.get().getSampleHeaders().get(selectedIndex), smooth);
             }

--- a/client/src/main/java/org/iconic/project/processing/ProcessDataController.java
+++ b/client/src/main/java/org/iconic/project/processing/ProcessDataController.java
@@ -302,6 +302,8 @@ public class ProcessDataController implements Initializable {
             return;
         }
 
+        resetEmptyTextField(tfSmoothingWindow, "0");
+
         int selectedIndex = lvFeatures.getSelectionModel().getSelectedIndex();
         if (selectedIndex != -1) {
             Optional<DataManager<Double>> dataManager = getDataManager();
@@ -372,7 +374,11 @@ public class ProcessDataController implements Initializable {
             return;
         }
 
+        resetEmptyTextField(tfNormaliseMin, "0");
+        resetEmptyTextField(tfNormaliseMax, "1");
+
         int selectedIndex = lvFeatures.getSelectionModel().getSelectedIndex();
+
         if (selectedIndex != -1) {
             Optional<DataManager<Double>> dataManager = getDataManager();
 
@@ -404,6 +410,8 @@ public class ProcessDataController implements Initializable {
         if (lvFeatures == null) {
             return;
         }
+
+        resetEmptyTextField(tfOffsetValue, "0");
 
         int selectedIndex = lvFeatures.getSelectionModel().getSelectedIndex();
         if (selectedIndex >= 0) {
@@ -669,6 +677,13 @@ public class ProcessDataController implements Initializable {
         cbOffset.setSelected(false);
 
         resetCheckboxFlag = false;
+    }
+
+    private void resetEmptyTextField(TextField textField, String resetValue) {
+        if (textField.getText().isEmpty()) {
+            textField.setText(resetValue);
+            textField.positionCaret(resetValue.length());
+        }
     }
 
     /**

--- a/client/src/main/resources/views/workspace/ProcessDataView.fxml
+++ b/client/src/main/resources/views/workspace/ProcessDataView.fxml
@@ -72,7 +72,8 @@
                     <CheckBox fx:id="cbSmoothData" text="Smooth data points" disable="true"/>
                     <VBox fx:id="vbSmoothData" visible="false" managed="false">
                         <HBox>
-                            <Button text="Smooth Automatically" onAction="#smoothDatasetFeature"/>
+                            <Label text="Smoothing window:"><padding><Insets left="25" right="10"/></padding></Label>
+                            <TextField fx:id="tfSmoothingWindow" text="2" onAction="#smoothDatasetFeature"/>
                         </HBox>
                     </VBox>
                     <Separator/>


### PR DESCRIPTION
**Changes**
- User can now specify a smoothing window in the GUI
- Added error checking to the preprocessing textfields (smoothing window field only allows integers, normalise + offset fields only allows integers and decimals)


Doesn't crash the search so that's always good