### PR TITLE
Added order labels next to preprocessors after they're applied

### DIFF
--- a/client/src/main/resources/views/workspace/ProcessDataView.fxml
+++ b/client/src/main/resources/views/workspace/ProcessDataView.fxml
@@ -70,7 +70,13 @@
                 <VBox prefWidth="${screen.visualBounds.width*0.66}" spacing="5">
                     <padding><Insets top="10" bottom="10" left="10" right="10"/></padding>
 
-                    <CheckBox fx:id="cbSmoothData" text="Smooth data points" disable="true"/>
+                    <HBox>
+                        <CheckBox fx:id="cbSmoothData" text="Smooth data points" disable="true"/>
+                        <Region HBox.hgrow="ALWAYS"/>
+                        <Label fx:id="lbSmoothOrder" textAlignment="RIGHT">
+                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                        </Label>
+                    </HBox>
                     <VBox fx:id="vbSmoothData" visible="false" managed="false">
                         <HBox>
                             <Label text="Smoothing window:"><padding><Insets left="25" right="10"/></padding></Label>
@@ -79,7 +85,14 @@
                     </VBox>
                     <Separator/>
 
-                    <CheckBox fx:id="cbHandleMissingValues" text="Handle missing values" disable="true"/>
+
+                    <HBox>
+                        <CheckBox fx:id="cbHandleMissingValues" text="Handle missing values" disable="true"/>
+                        <Region HBox.hgrow="ALWAYS"/>
+                        <Label fx:id="lbHandleMissingValuesOrder" textAlignment="RIGHT">
+                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                        </Label>
+                    </HBox>
                     <VBox fx:id="vbHandleMissingValues" visible="false" managed="false">
                         <HBox>
                             <Label text="Method:"><padding><Insets left="25" right="10"/></padding></Label>
@@ -99,7 +112,13 @@
                     </VBox>
                     <Separator/>
 
-                    <CheckBox fx:id="cbRemoveOutliers" text="Remove outliers" disable="true"/>
+                    <HBox>
+                        <CheckBox fx:id="cbRemoveOutliers" text="Remove outliers" disable="true"/>
+                        <Region HBox.hgrow="ALWAYS"/>
+                        <Label fx:id="lbRemoveOutliersOrder" textAlignment="RIGHT">
+                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                        </Label>
+                    </HBox>
                     <VBox fx:id="vbRemoveOutliers" visible="false" managed="false">
                         <HBox>
                             <Label text="Min Value:"><padding><Insets left="25" right="10"/></padding></Label>
@@ -112,7 +131,13 @@
                     </VBox>
                     <Separator/>
 
-                    <CheckBox fx:id="cbNormalise" text="Normalise scale" disable="true"/>
+                    <HBox>
+                        <CheckBox fx:id="cbNormalise" text="Normalise scale" disable="true"/>
+                        <Region HBox.hgrow="ALWAYS"/>
+                        <Label fx:id="lbNormaliseOrder" textAlignment="RIGHT">
+                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                        </Label>
+                    </HBox>
                     <VBox fx:id="vbNormalise" visible="false" managed="false">
                         <HBox>
                             <Label text="Min Value:"><padding><Insets left="25" right="10"/></padding></Label>
@@ -125,7 +150,13 @@
                     </VBox>
                     <Separator/>
 
-                    <CheckBox fx:id="cbOffset" text="Offset data" disable="true"/>
+                    <HBox>
+                        <CheckBox fx:id="cbOffset" text="Offset data" disable="true"/>
+                        <Region HBox.hgrow="ALWAYS"/>
+                        <Label fx:id="lbOffsetValuesOrder" textAlignment="RIGHT">
+                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                        </Label>
+                    </HBox>
                     <VBox fx:id="vbOffset" visible="false" managed="false">
                         <HBox>
                             <Label text="Offset values by:"><padding><Insets left="25" right="10"/></padding></Label>


### PR DESCRIPTION
**Changes**
- An order number is now added to the right of a preprocessor which corresponds with the order in which that preprocessor was applied
- Added an explanatory tooltip when hovering over the order labels
