### PR TITLE
Results screen layout + target expression

### DIFF
--- a/client/src/main/java/org/iconic/project/ProjectTreeController.java
+++ b/client/src/main/java/org/iconic/project/ProjectTreeController.java
@@ -320,7 +320,7 @@ public class ProjectTreeController implements Initializable {
                     );
             ComboBox<EvolutionaryAlgorithmType> availableAlgorithms = new ComboBox<>(options);
 
-            availableAlgorithms.setPromptText("Evolutionary Algorithm");
+            availableAlgorithms.setPromptText("Select an evolutionary algorithm");
 
             VBox contentArea = new VBox();
             contentArea.getChildren().add(configurationName);

--- a/client/src/main/java/org/iconic/project/definition/DefineSearchController.java
+++ b/client/src/main/java/org/iconic/project/definition/DefineSearchController.java
@@ -24,6 +24,7 @@ package org.iconic.project.definition;
 import com.google.inject.Inject;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
+import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -133,6 +134,8 @@ public class DefineSearchController implements Initializable, DefineSearchServic
         cbDatasets.valueProperty().addListener(this::updateDataset);
         defineTab.setOnSelectionChanged(event -> updateTab());
 
+        tfTargetExpression.focusedProperty().addListener(focusListener);
+
         updateTab();
     }
 
@@ -231,6 +234,7 @@ public class DefineSearchController implements Initializable, DefineSearchServic
 
         SearchConfigurationModel configModel = (SearchConfigurationModel) item;
         configModel.setDatasetModel(newValue);
+        loadFunction();
     }
 
     private void loadFunction() {
@@ -253,7 +257,7 @@ public class DefineSearchController implements Initializable, DefineSearchServic
                 log.error("No headers found in this dataset");
             }
 
-            // NOTE(Meyer): Must check if not null otherwise injection will cause an NPE (it's dumb, I know)
+            // NOTE(Meyer): Must check if not null otherwise injection will cause an NPE
             if (tfTargetExpression != null) {
                 tfTargetExpression.setText(functionStr);
                 dataset.get().defineFunction(functionStr);
@@ -318,4 +322,22 @@ public class DefineSearchController implements Initializable, DefineSearchServic
     private Map<String, Node> getConfigViews() {
         return configViews;
     }
+
+
+    private ChangeListener<Boolean> focusListener = new ChangeListener<Boolean>() {
+        @Override
+        public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
+            if (!newValue) {
+                // Get the data from the definition field, send it to the data manager to parse
+                Optional<DataManager<Double>> dataset = getDataManager();
+
+                String functionDefinition = tfTargetExpression.getText();
+
+                if(dataset.isPresent()) {
+                    setFunction();
+                    dataset.get().defineFunction(functionDefinition);
+                }
+            }
+        }
+    };
 }

--- a/client/src/main/resources/views/workspace/ResultsView.fxml
+++ b/client/src/main/resources/views/workspace/ResultsView.fxml
@@ -64,26 +64,6 @@
                     </font>
                 </Label>
             </HBox>
-            <!-- Right-header -->
-            <HBox spacing="5" prefWidth="${screen.visualBounds.width*0.4}">
-                <padding>
-                    <Insets top="10" bottom="10" left="10" right="10"/>
-                </padding>
-                <Label text="Plot Type: ">
-                    <font>
-                        <Font size="18.0" />
-                    </font>
-                </Label>
-				<ComboBox value="Solution Fit Plot (default)">
-					<items>
-						<FXCollections fx:factory="observableArrayList">
-							<String fx:value="Solution Fit Plot (default)"/>
-							<String fx:value="Observed vs. Predicted Plot"/>
-							<String fx:value="Classification ROC Plot"/>
-						</FXCollections>
-					</items>
-				</ComboBox>
-            </HBox>
         </HBox>
 
         <Separator/>
@@ -109,7 +89,8 @@
                     <Insets top="10" bottom="10" left="10" right="10"/>
                 </padding>
                 <AnchorPane>
-                    <LineChart AnchorPane.topAnchor="0"
+                    <LineChart title="Solution Fit Plot"
+                               AnchorPane.topAnchor="0"
                                AnchorPane.leftAnchor="0"
                                AnchorPane.rightAnchor="0"
                                AnchorPane.BottomAnchor="0">
@@ -166,25 +147,6 @@
                         </GridPane>
                     </content>
                 </ScrollPane>
-            </VBox>
-            <VBox spacing="5" prefWidth="${screen.visualBounds.width*0.4}">
-                <padding>
-                    <Insets top="10" bottom="10" left="10" right="10"/>
-                </padding>
-                <AnchorPane>
-                    <LineChart title="Accuracy vs Complexity"
-                               AnchorPane.topAnchor="0"
-                               AnchorPane.leftAnchor="0"
-                               AnchorPane.rightAnchor="0"
-                               AnchorPane.BottomAnchor="0">
-                        <xAxis>
-                            <CategoryAxis side="BOTTOM"/>
-                        </xAxis>
-                        <yAxis>
-                            <NumberAxis side="LEFT"/>
-                        </yAxis>
-                    </LineChart>
-                </AnchorPane>
             </VBox>
         </HBox>
     </VBox>


### PR DESCRIPTION
Everything is pretty minor and front end only. 

**Changes**

_**Results Tab**_
-  Removed the _Accuracy vs Complexity_ line chart
-  Removed the options dropdown of the line chart that will show the expected vs actual
   -  Added heading to the linechart

_**Expression Tab**_
-  Fixed the target expression stuff not working with how the definition page changed
    - A lot of code went missing somewhere but it's back now, and the features are selected the exact same as before

_**Search Configuration Window**_
-  Changed the text of the drop to say "Select an evolutionary algorithm"
   - Better user friendliness - I was wondering why the config wasn't adding as I assumed that _Evolutionary Algorithm_ was default
