### PR TITLE
Feature/gui cleanup

### DIFF
--- a/api/src/main/java/org/iconic/ea/data/FeatureClass.java
+++ b/api/src/main/java/org/iconic/ea/data/FeatureClass.java
@@ -169,27 +169,4 @@ public abstract class FeatureClass<T> {
     public boolean isMissingValues() {
         return missingValues;
     }
-
-    /**
-     *  TEMPORARY DEBUG METHODS
-     */
-    private void printValues(List<T> values) {
-        String valueString = "";
-
-        for (int i=0; i < values.size(); i++) {
-            valueString += values.get(i) + " ";
-        }
-
-        System.out.println(valueString);
-    }
-
-    private void printPreprocessors() {
-        String test="";
-
-        for (int i=0; i < preprocessors.size(); i++) {
-            test += " " + preprocessors.get(i).getTransformType();
-        }
-
-        System.out.println(test);
-    }
 }

--- a/api/src/main/java/org/iconic/ea/data/preprocessing/RemoveOutliers.java
+++ b/api/src/main/java/org/iconic/ea/data/preprocessing/RemoveOutliers.java
@@ -28,7 +28,14 @@ import java.util.Comparator;
 public class RemoveOutliers extends Preprocessor<Number> {
     private double threshold = 2.00;
 
-    // Replaces any number outside of the range with null
+    /**
+     * Replaces each value with null if it is deemed to be an outlier. A point is considered an outlier if the following
+     * comparison returns true:
+     *                                      ((mean - value) > threshold * IQR)
+     *
+     * @param values Values to operator on
+     * @return Returns the values with all outliers removed
+     */
     public List<Number> apply(List<Number> values) {
         // Calculate the mean and IQR
         double mean = calculateMean(values);
@@ -46,6 +53,12 @@ public class RemoveOutliers extends Preprocessor<Number> {
         return values;
     }
 
+    /**
+     * Calculates the mean of a given list of values.
+     *
+     * @param values Input values
+     * @return Mean value as a double
+     */
     private double calculateMean(List<Number> values) {
         double total = 0;
 
@@ -58,6 +71,12 @@ public class RemoveOutliers extends Preprocessor<Number> {
         return total / values.size();
     }
 
+    /**
+     * Calculates the median of a given list of values.
+     *
+     * @param values Input values
+     * @return Median value as a double
+     */
     private double calculateMedian(Double[] values) {
         Double center = values[values.length / 2];
 
@@ -76,23 +95,31 @@ public class RemoveOutliers extends Preprocessor<Number> {
         }
     }
 
+    /**
+     * Calculates the interquartile range (IQR) of a given set of values, using the formula:
+     *                            IQR = Quadrant 3 - Quadrant 1
+     *
+     * @param values Input values
+     * @return IQR value as a double
+     */
     private double calculateIQR(List<Number> values) {
         // Convert values to an array and sort
         Double[] numbers = values.toArray(new Double[values.size()]);
         Arrays.sort(numbers, new Comparator<Double>() {
-                    @Override
-                    public int compare(Double o1, Double o2) {
-                        if (o1 != null && o2 != null) {
-                            return o1.compareTo(o2);
-                        } else {
-                            return 0;
-                        }
-                    }
-                });
+            @Override
+            public int compare(Double o1, Double o2) {
+                if (o1 != null && o2 != null) {
+                    return o1.compareTo(o2);
+                } else {
+                    return 0;
+                }
+            }
+        });
 
-                // Calculate the size of the first/second half sets
+        // Calculate the size of the first/second half sets
         int splitSize = (int)Math.floor(numbers.length / 2);
 
+        // Instantiate first/second half arrays given the splitSize
         Double[] firstHalf = new Double[splitSize];
         Double[] secondHalf = new Double[splitSize];
 

--- a/client/src/main/java/org/iconic/control/WorkspaceTab.java
+++ b/client/src/main/java/org/iconic/control/WorkspaceTab.java
@@ -43,6 +43,7 @@ public class WorkspaceTab extends Tab {
         ALL,
         DATASET,
         SEARCH,
-        OTHER
+        REPORT,
+        OTHER,
     }
 }

--- a/client/src/main/java/org/iconic/control/WorkspaceTab.java
+++ b/client/src/main/java/org/iconic/control/WorkspaceTab.java
@@ -41,6 +41,7 @@ public class WorkspaceTab extends Tab {
 
     public enum TabType {
         ALL,
+        INPUT,
         DATASET,
         SEARCH,
         REPORT,

--- a/client/src/main/java/org/iconic/project/ProjectTreeController.java
+++ b/client/src/main/java/org/iconic/project/ProjectTreeController.java
@@ -320,7 +320,7 @@ public class ProjectTreeController implements Initializable {
                     );
             ComboBox<EvolutionaryAlgorithmType> availableAlgorithms = new ComboBox<>(options);
 
-            availableAlgorithms.setPromptText("Evolutionary Algorithm");
+            availableAlgorithms.getSelectionModel().selectFirst();
 
             VBox contentArea = new VBox();
             contentArea.getChildren().add(configurationName);

--- a/client/src/main/java/org/iconic/project/processing/ProcessDataController.java
+++ b/client/src/main/java/org/iconic/project/processing/ProcessDataController.java
@@ -133,8 +133,10 @@ public class ProcessDataController implements Initializable {
         addCheckBoxChangeListener(cbNormalise, vbNormalise);
         addCheckBoxChangeListener(cbOffset, vbOffset);
 
+        // Add a combobox listener for handle missing values options
         addComboBoxChangeListener(cbHandleMissingValuesOptions, cbHandleMissingValues);
 
+        // Add listeners to each input text field
         addTextFieldChangeListener(tfSmoothingWindow, false);
         addTextFieldChangeListener(tfNormaliseMin, true);
         addTextFieldChangeListener(tfNormaliseMax, true);
@@ -142,6 +144,7 @@ public class ProcessDataController implements Initializable {
 
         processTab.setOnSelectionChanged(event -> updateWorkspace());
 
+        // Setup spinners converter and add a listener
         initializeSpinner();
         addSpinnerChangeListener(spRemoveOutliersThreshold, cbRemoveOutliers);
     }
@@ -228,8 +231,8 @@ public class ProcessDataController implements Initializable {
         combobox.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
             Optional<DataManager<Double>> dataManager = getDataManager();
 
-                if (dataManager.isPresent()) {
-                    removeExistingPreprocessor(checkbox);
+            if (dataManager.isPresent()) {
+                removeExistingPreprocessor(checkbox);
 
                 int selectedIndex = lvFeatures.getSelectionModel().getSelectedIndex();
                 String selectedHeader = dataManager.get().getSampleHeaders().get(selectedIndex);
@@ -241,6 +244,12 @@ public class ProcessDataController implements Initializable {
         });
     }
 
+    /**
+     * Adds a ChangeListener to the specified spinner to fire an event when the spinner's value is changed.
+     *
+     * @param spinner The selected spinner
+     * @param checkbox The checkbox that the spinner belongs to
+     */
     private void addSpinnerChangeListener(Spinner<Double> spinner, CheckBox checkbox) {
         if (spinner == null) {
             return;
@@ -277,10 +286,12 @@ public class ProcessDataController implements Initializable {
             @Override
             public void changed(ObservableValue<? extends String> observable, String oldValue, String newValue) {
                 if (allowDecimals) {
+                    // Allows all numbers and decimal points
                     if (!newValue.matches("\\d*(\\.\\d*)?")) {
                         textField.setText(oldValue);
                     }
                 } else {
+                    // Allows only numbers
                     if (!newValue.matches("\\d*")) {
                         textField.setText(newValue.replaceAll("[^\\d]", ""));
                     }
@@ -714,10 +725,18 @@ public class ProcessDataController implements Initializable {
         cbOffset.setDisable(false);
     }
 
+    /**
+     * Enables a specific pre-processing checkbox that is provided as input
+     *
+     * @param checkbox Selected checkbox
+     */
     private void enablePreprocessingCheckBox(CheckBox checkbox) {
         checkbox.setDisable(false);
     }
 
+    /**
+     * Disables all pre-processing checkboxes at once.
+     */
     private void disablePreprocessingCheckBoxes() {
         cbSmoothData.setDisable(true);
         cbHandleMissingValues.setDisable(true);
@@ -847,6 +866,13 @@ public class ProcessDataController implements Initializable {
         resetCheckboxFlag = false;
     }
 
+    /**
+     * If an input text field is empty and the user tries to submit the field, then this method replaces the empty field
+     * with a reset value (e.g. 0).
+     *
+     * @param textField The text field to test if empty
+     * @param resetValue The reset value if the text field is empty
+     */
     private void resetEmptyTextField(TextField textField, String resetValue) {
         if (textField.getText().isEmpty()) {
             textField.setText(resetValue);

--- a/client/src/main/java/org/iconic/project/search/config/CgpConfigurationController.java
+++ b/client/src/main/java/org/iconic/project/search/config/CgpConfigurationController.java
@@ -115,7 +115,10 @@ public class CgpConfigurationController implements Initializable {
                 FXCollections.emptyObservableList();
 
         cbMutators.setItems(mutators);
+        cbMutators.getSelectionModel().selectFirst();
+
         cbCrossovers.setItems(crossovers);
+        cbCrossovers.getSelectionModel().selectFirst();
 
         bindTextProperty(configModel.populationSizeProperty(), tfPopulationSize.textProperty());
         bindTextProperty(configModel.numGenerationsProperty(), tfNumGenerations.textProperty());

--- a/client/src/main/java/org/iconic/project/search/config/GepConfigurationController.java
+++ b/client/src/main/java/org/iconic/project/search/config/GepConfigurationController.java
@@ -108,7 +108,10 @@ public class GepConfigurationController implements Initializable {
                 );
 
         cbMutators.setItems(mutators);
+        cbMutators.getSelectionModel().selectFirst();
+
         cbCrossovers.setItems(crossovers);
+        cbCrossovers.getSelectionModel().selectFirst();
 
         bindTextProperty(configModel.populationSizeProperty(), tfPopulationSize.textProperty());
         bindTextProperty(configModel.numGenerationsProperty(), tfNumGenerations.textProperty());

--- a/client/src/main/java/org/iconic/workspace/WorkspaceController.java
+++ b/client/src/main/java/org/iconic/workspace/WorkspaceController.java
@@ -38,7 +38,9 @@ import org.iconic.project.dataset.DatasetModel;
 import org.iconic.project.search.config.SearchConfigurationModel;
 
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.ResourceBundle;
+import java.util.List;
 
 /**
  * <p>
@@ -82,14 +84,19 @@ public class WorkspaceController implements Initializable {
      */
     private void updateWorkspace() {
         Displayable item = getWorkspaceService().getActiveWorkspaceItem();
+        List<WorkspaceTab.TabType> activeTabs = new ArrayList<>();
 
         if (item instanceof DatasetModel) {
-            updateAvailableTabs(WorkspaceTab.TabType.DATASET);
+            activeTabs.add(WorkspaceTab.TabType.DATASET);
+            activeTabs.add(WorkspaceTab.TabType.INPUT);
         } else if (item instanceof SearchConfigurationModel) {
-            updateAvailableTabs(WorkspaceTab.TabType.SEARCH);
+            activeTabs.add(WorkspaceTab.TabType.SEARCH);
         } else {
-            updateAvailableTabs(WorkspaceTab.TabType.OTHER);
+            activeTabs.add(WorkspaceTab.TabType.INPUT);
         }
+
+        updateAvailableTabs(activeTabs);
+
         // If no dataset is selected clear the UI of dataset related elements
         // TODO: if a search is selected, do not clear the results
         if (!(item instanceof DatasetModel)) {
@@ -98,27 +105,30 @@ public class WorkspaceController implements Initializable {
     }
 
     /**
-     * <p>Update the tabs that are available for selection based on the provided tab type</p>
+     * <p>Update the tabs that are available for selection based on the provided tab types</p>
      *
-     * @param availableTabs The tab types to enable, tabs of other types will be disabled
+     * @param availableTabs The list of tab types to enable, tabs of other types will be disabled
      */
-    private void updateAvailableTabs(WorkspaceTab.TabType availableTabs) {
+    private void updateAvailableTabs(List<WorkspaceTab.TabType> availableTabs) {
         if (tbpWorkspace == null) {
             return;
         }
 
         tbpWorkspace.getTabs().forEach(tab -> {
             WorkspaceTab wTab = (WorkspaceTab) tab;
-            if (wTab.getTabType().equals(availableTabs) || wTab.getTabType().equals(WorkspaceTab.TabType.ALL)) {
-                tab.setDisable(false);
-            } else {
-                tab.setDisable(true);
+
+            for (int i=0; i < availableTabs.size(); i++) {
+                if (wTab.getTabType().equals(availableTabs.get(i)) || wTab.getTabType().equals(WorkspaceTab.TabType.ALL)) {
+                    tab.setDisable(false);
+                    break;
+                } else {
+                    tab.setDisable(true);
+                }
             }
         });
 
-        // If the current selected tab is disabled, change the user's
-        // selection to the first enabled tab if available
-//        updateTabSelection();
+        // If the current selected tab is disabled, change the user's selection to the first enabled tab if available
+        //updateTabSelection();
     }
 
     /**

--- a/client/src/main/resources/views/project/search/CgpConfigurationView.fxml
+++ b/client/src/main/resources/views/project/search/CgpConfigurationView.fxml
@@ -127,7 +127,7 @@
                     </Tooltip>
                 </tooltip>
             </Label>
-            <MutatorComboBox fx:id="cbMutators" promptText="Select a mutator"/>
+            <MutatorComboBox fx:id="cbMutators"/>
         </VBox>
         <LabelledSlider fx:id="sldrMutationRate" text="Mutation Rate"/>
     </HBox>
@@ -143,7 +143,7 @@
                     </Tooltip>
                 </tooltip>
             </Label>
-            <CrossoverComboBox fx:id="cbCrossovers" promptText="Select a crossover operator"/>
+            <CrossoverComboBox fx:id="cbCrossovers"/>
         </VBox>
         <LabelledSlider fx:id="sldrCrossoverRate" text="Crossover Rate" disable="true"/>
     </HBox>

--- a/client/src/main/resources/views/project/search/CgpConfigurationView.fxml
+++ b/client/src/main/resources/views/project/search/CgpConfigurationView.fxml
@@ -27,6 +27,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.Screen?>
+<?import javafx.scene.text.Font?>
 
 <?import org.iconic.control.operator.evolutionary.MutatorComboBox?>
 <?import org.iconic.control.LabelledSlider?>
@@ -46,29 +47,71 @@
     </padding>
     <Separator/>
     <VBox spacing="10">
-        <Label labelFor="$tfPopulationSize" text="Population Size: "/>
+        <Label labelFor="$tfPopulationSize" text="Population Size: ">
+            <tooltip>
+                <Tooltip wrapText="true" maxWidth="500"
+                         text="The number of 'children' generated for each generation of the search.">
+                    <font><Font size="12.0"/></font>
+                </Tooltip>
+            </tooltip>
+        </Label>
         <TextField fx:id="tfPopulationSize" promptText="Size of the Population"/>
     </VBox>
     <VBox spacing="10">
-        <Label labelFor="$tfNumGenerations" text="Generations: "/>
+        <Label labelFor="$tfNumGenerations" text="Generations: ">
+            <tooltip>
+                <Tooltip wrapText="true" maxWidth="500"
+                         text="The number of iterations that the algorithm should run for. A value of 0 means that the algorithm will run indefinitely until the user pauses or stops the search.">
+                    <font><Font size="12.0"/></font>
+                </Tooltip>
+            </tooltip>
+        </Label>
         <TextField fx:id="tfNumGenerations" promptText="Number of generations to evolve for. Leave this at zero to stop manually"/>
     </VBox>
     <Separator/>
     <HBox spacing="5">
         <VBox spacing="10">
-            <Label labelFor="$tfNumOutputs" text="Number of Outputs: "/>
+            <Label labelFor="$tfNumOutputs" text="Number of Outputs: ">
+                <tooltip>
+                    <Tooltip wrapText="true" maxWidth="500"
+                             text="The number of outputs that the CGP chromosome can have, effectively splitting a solution into multiple parts.">
+                        <font><Font size="12.0"/></font>
+                    </Tooltip>
+                </tooltip>
+            </Label>
             <TextField fx:id="tfNumOutputs" promptText="Number of Outputs"/>
         </VBox>
         <VBox spacing="10">
-            <Label labelFor="$tfNumColumns" text="Number of Columns: "/>
+            <Label labelFor="$tfNumColumns" text="Number of Columns: ">
+                <tooltip>
+                    <Tooltip wrapText="true" maxWidth="500"
+                             text="The number of columns in the CGP chromosomes dimensions.">
+                        <font><Font size="12.0"/></font>
+                    </Tooltip>
+                </tooltip>
+            </Label>
             <TextField fx:id="tfNumColumns" promptText="Number of Columns"/>
         </VBox>
         <VBox spacing="10">
-            <Label labelFor="$tfNumRows" text="Number of Rows: "/>
+            <Label labelFor="$tfNumRows" text="Number of Rows: ">
+                <tooltip>
+                    <Tooltip wrapText="true" maxWidth="500"
+                             text="The number of rows in the CGP chromosomes dimensions. It is recommended to set this value to 1 as default.">
+                        <font><Font size="12.0"/></font>
+                    </Tooltip>
+                </tooltip>
+            </Label>
             <TextField fx:id="tfNumRows" promptText="Number of Rows"/>
         </VBox>
         <VBox spacing="10">
-            <Label labelFor="$tfNumLevelsBack" text="Number of Levels Back: "/>
+            <Label labelFor="$tfNumLevelsBack" text="Number of Levels Back: ">
+                <tooltip>
+                    <Tooltip wrapText="true" maxWidth="500"
+                             text="The number of levels back that any node in the CGP chromosome can reach to connect to another node.">
+                        <font><Font size="12.0"/></font>
+                    </Tooltip>
+                </tooltip>
+            </Label>
             <TextField fx:id="tfNumLevelsBack" promptText="Number of Levels Back"/>
         </VBox>
     </HBox>
@@ -76,7 +119,14 @@
     <HBox spacing="20">
         <padding><Insets top="25"/></padding>
         <VBox spacing="10">
-            <Label labelFor="$cbMutators" text="Mutation: "/>
+            <Label labelFor="$cbMutators" text="Mutation: ">
+                <tooltip>
+                    <Tooltip wrapText="true" maxWidth="500"
+                             text="Mutation is a small random change within each 'child's' chromosomes. It is used to maintain and introduce diversity within the genetic population. The chance of a mutation occurring can be controlled by the mutation rate slider.">
+                        <font><Font size="12.0"/></font>
+                    </Tooltip>
+                </tooltip>
+            </Label>
             <MutatorComboBox fx:id="cbMutators" promptText="Select a mutator"/>
         </VBox>
         <LabelledSlider fx:id="sldrMutationRate" text="Mutation Rate"/>
@@ -85,9 +135,16 @@
     <HBox spacing="20">
         <padding><Insets top="25"/></padding>
         <VBox spacing="10">
-            <Label labelFor="$cbCrossovers" text="Crossover: " />
+            <Label labelFor="$cbCrossovers" text="Crossover: ">
+                <tooltip>
+                    <Tooltip wrapText="true" maxWidth="500"
+                             text="Crossover is the act of replacing part of a 'child's' genes with those of a parents within the existing population. The crossover rate controls how likely it is that this process will occur for each individual.">
+                        <font><Font size="12.0"/></font>
+                    </Tooltip>
+                </tooltip>
+            </Label>
             <CrossoverComboBox fx:id="cbCrossovers" promptText="Select a crossover operator"/>
         </VBox>
-        <LabelledSlider fx:id="sldrCrossoverRate" text="Crossover Rate"/>
+        <LabelledSlider fx:id="sldrCrossoverRate" text="Crossover Rate" disable="true"/>
     </HBox>
 </VBox>

--- a/client/src/main/resources/views/project/search/GepConfigurationView.fxml
+++ b/client/src/main/resources/views/project/search/GepConfigurationView.fxml
@@ -27,6 +27,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.Screen?>
+<?import javafx.scene.text.Font?>
 
 <?import org.iconic.control.operator.evolutionary.MutatorComboBox?>
 <?import org.iconic.control.LabelledSlider?>
@@ -48,23 +49,51 @@
     </padding>
     <Separator/>
     <VBox spacing="10">
-        <Label labelFor="$tfPopulationSize" text="Population Size: "/>
+        <Label labelFor="$tfPopulationSize" text="Population Size: ">
+            <tooltip>
+                <Tooltip wrapText="true" maxWidth="500"
+                         text="The number of 'children' generated for each generation of the search.">
+                    <font><Font size="12.0"/></font>
+                </Tooltip>
+            </tooltip>
+        </Label>
         <TextField fx:id="tfPopulationSize" promptText="Size of the Population"/>
     </VBox>
     <VBox spacing="10">
-        <Label labelFor="$tfNumGenerations" text="Generations: "/>
+        <Label labelFor="$tfNumGenerations" text="Generations: ">
+            <tooltip>
+                <Tooltip wrapText="true" maxWidth="500"
+                         text="The number of iterations that the algorithm should run for. A value of 0 means that the algorithm will run indefinitely until the user pauses or stops the search.">
+                    <font><Font size="12.0"/></font>
+                </Tooltip>
+            </tooltip>
+        </Label>
         <TextField fx:id="tfNumGenerations" promptText="Number of generations to evolve for. Leave this at zero to stop manually"/>
     </VBox>
     <Separator/>
     <VBox spacing="10">
-        <Label labelFor="$tfHeadLength" text="Head Length: "/>
+        <Label labelFor="$tfHeadLength" text="Head Length: ">
+            <tooltip>
+                <Tooltip wrapText="true" maxWidth="500"
+                         text="Head length is the number of non-terminal nodes in the chromosome.">
+                    <font><Font size="12.0"/></font>
+                </Tooltip>
+            </tooltip>
+        </Label>
         <TextField fx:id="tfHeadLength" promptText="Head Length"/>
     </VBox>
     <Separator/>
     <HBox spacing="20">
         <padding><Insets top="25"/></padding>
         <VBox spacing="10">
-            <Label labelFor="$cbMutators" prefWidth="150" text="Mutation: "/>
+            <Label labelFor="$cbMutators" prefWidth="150" text="Mutation: ">
+                <tooltip>
+                    <Tooltip wrapText="true" maxWidth="500"
+                             text="Mutation is a small random change within each 'child's' chromosomes. It is used to maintain and introduce diversity within the genetic population. The chance of a mutation occurring can be controlled by the mutation rate slider.">
+                        <font><Font size="12.0"/></font>
+                    </Tooltip>
+                </tooltip>
+            </Label>
             <MutatorComboBox fx:id="cbMutators" promptText="Select a mutator"/>
         </VBox>
         <LabelledSlider fx:id="sldrMutationRate" text="Mutation Rate"/>
@@ -73,7 +102,14 @@
     <HBox spacing="20">
         <padding><Insets top="25"/></padding>
         <VBox spacing="10">
-            <Label labelFor="$cbCrossovers" prefWidth="150" text="Crossover: "/>
+            <Label labelFor="$cbCrossovers" prefWidth="150" text="Crossover: ">
+                <tooltip>
+                    <Tooltip wrapText="true" maxWidth="500"
+                             text="Crossover is the act of replacing part of a 'child's' genes with those of a parents within the existing population. The crossover rate controls how likely it is that this process will occur for each individual.">
+                        <font><Font size="12.0"/></font>
+                    </Tooltip>
+                </tooltip>
+            </Label>
             <CrossoverComboBox fx:id="cbCrossovers" promptText="Select a crossover operator"/>
         </VBox>
         <LabelledSlider fx:id="sldrCrossoverRate" text="Crossover Rate"/>

--- a/client/src/main/resources/views/project/search/GepConfigurationView.fxml
+++ b/client/src/main/resources/views/project/search/GepConfigurationView.fxml
@@ -94,7 +94,7 @@
                     </Tooltip>
                 </tooltip>
             </Label>
-            <MutatorComboBox fx:id="cbMutators" promptText="Select a mutator"/>
+            <MutatorComboBox fx:id="cbMutators"/>
         </VBox>
         <LabelledSlider fx:id="sldrMutationRate" text="Mutation Rate"/>
     </HBox>
@@ -110,7 +110,7 @@
                     </Tooltip>
                 </tooltip>
             </Label>
-            <CrossoverComboBox fx:id="cbCrossovers" promptText="Select a crossover operator"/>
+            <CrossoverComboBox fx:id="cbCrossovers"/>
         </VBox>
         <LabelledSlider fx:id="sldrCrossoverRate" text="Crossover Rate"/>
     </HBox>

--- a/client/src/main/resources/views/workspace/DefineSearchView.fxml
+++ b/client/src/main/resources/views/workspace/DefineSearchView.fxml
@@ -56,6 +56,13 @@
         <VBox spacing="5" alignment="CENTER">
             <HBox spacing="5">
                 <Label text="Target Expression:">
+                    <tooltip>
+                        <Tooltip wrapText="true" maxWidth="500"
+                                 text="The equation which the search will attempt to satisfy.">
+                            <font><Font size="12.0"/></font>
+                        </Tooltip>
+                    </tooltip>
+
                     <padding>
                         <Insets left="20" right="20"/>
                     </padding>

--- a/client/src/main/resources/views/workspace/DefineSearchView.fxml
+++ b/client/src/main/resources/views/workspace/DefineSearchView.fxml
@@ -72,15 +72,10 @@
                 </Label>
                 <TextField fx:id="tfTargetExpression" text="y = f(x)"/>
                 <DatasetComboBox fx:id="cbDatasets"/>
-                <ComboBox value="Absolute error (default)">
+                <ComboBox value="Mean Absolute Error">
                     <items>
                         <FXCollections fx:factory="observableArrayList">
-                            <String fx:value="Mean Squared Error (MSE)"/>
-                            <String fx:value="Absolute Error"/>
-                            <String fx:value="Squared Error"/>
-                            <String fx:value="Root Mean Squared Error (RMSE)"/>
-                            <String fx:value="Maximum Error"/>
-                            <String fx:value="Median Error"/>
+                            <String fx:value="Mean Absolute Error"/>
                         </FXCollections>
                     </items>
                 </ComboBox>

--- a/client/src/main/resources/views/workspace/InputDataView.fxml
+++ b/client/src/main/resources/views/workspace/InputDataView.fxml
@@ -31,7 +31,7 @@
 <?import javafx.scene.text.Text?>
 <?import org.iconic.control.WorkspaceTab?>
 <?import org.controlsfx.control.spreadsheet.SpreadsheetView?>
-<WorkspaceTab fx:id="inputTab" text="   Input Data" closable="false" tabType="ALL"
+<WorkspaceTab fx:id="inputTab" text="   Input Data" closable="false" tabType="INPUT"
               xmlns="http://javafx.com/javafx"
               xmlns:fx="http://javafx.com/fxml"
               fx:controller="org.iconic.project.input.InputDataController">

--- a/client/src/main/resources/views/workspace/ProcessDataView.fxml
+++ b/client/src/main/resources/views/workspace/ProcessDataView.fxml
@@ -30,7 +30,6 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
-<?import javafx.scene.text.Font?>
 <?import javafx.stage.Screen?>
 <?import org.iconic.control.WorkspaceTab?>
 <?import java.lang.*?>
@@ -74,7 +73,7 @@
                     <HBox>
                         <CheckBox fx:id="cbSmoothData" text="Smooth data points" disable="true">
                             <tooltip>
-                                <Tooltip wrapText="true" prefWidth="500"
+                                <Tooltip wrapText="true" maxWidth="500"
                                          text="Applies a 'Moving Average Filtering' algorithm to smooth the selected feature. You can specify a smoothing window, which is the number of neighbouring values that will be summed either side of each point. The average of this sum will become the new value for that point.">
                                     <font><Font size="12.0"/></font>
                                 </Tooltip>
@@ -103,7 +102,7 @@
                     <HBox>
                         <CheckBox fx:id="cbHandleMissingValues" text="Handle missing values" disable="true">
                             <tooltip>
-                                <Tooltip wrapText="true" prefWidth="500"
+                                <Tooltip wrapText="true" maxWidth="500"
                                          text="Removes all null (empty) elements from the selected feature, and replaces them with the selected option in the drop down list.">
                                     <font><Font size="12.0"/></font>
                                 </Tooltip>
@@ -142,7 +141,7 @@
                     <HBox>
                         <CheckBox fx:id="cbNormalise" text="Normalise scale" disable="true">
                             <tooltip>
-                                <Tooltip wrapText="true" prefWidth="500"
+                                <Tooltip wrapText="true" maxWidth="500"
                                          text="Scales all values within the selected feature to be between the specified minimum and maximum values.">
                                     <font><Font size="12.0"/></font>
                                 </Tooltip>
@@ -175,7 +174,7 @@
                     <HBox>
                         <CheckBox fx:id="cbRemoveOutliers" text="Remove outliers" disable="true">
                             <tooltip>
-                                <Tooltip wrapText="true" prefWidth="500"
+                                <Tooltip wrapText="true" maxWidth="500"
                                          text="Removes all points in the selected feature that are considered outliers. You can specify a threshold value that controls the tolerance with which outliers are calculated. High threshold = less points considered outliers. Low threshold = more points considered outliers.">
                                     <font><Font size="12.0"/></font>
                                 </Tooltip>
@@ -204,7 +203,7 @@
                     <HBox>
                         <CheckBox fx:id="cbOffset" text="Offset data" disable="true">
                             <tooltip>
-                                <Tooltip wrapText="true" prefWidth="500"
+                                <Tooltip wrapText="true" maxWidth="500"
                                          text="Shifts all values within the selected feature by the given offset value.">
                                     <font><Font size="12.0"/></font>
                                 </Tooltip>

--- a/client/src/main/resources/views/workspace/ProcessDataView.fxml
+++ b/client/src/main/resources/views/workspace/ProcessDataView.fxml
@@ -70,11 +70,25 @@
                 <VBox prefWidth="${screen.visualBounds.width*0.66}" spacing="5">
                     <padding><Insets top="10" bottom="10" left="10" right="10"/></padding>
 
+                    <!-- SMOOTH DATA POINTS -->
                     <HBox>
-                        <CheckBox fx:id="cbSmoothData" text="Smooth data points" disable="true"/>
+                        <CheckBox fx:id="cbSmoothData" text="Smooth data points" disable="true">
+                            <tooltip>
+                                <Tooltip wrapText="true" prefWidth="500"
+                                         text="Applies a 'Moving Average Filtering' algorithm to smooth the selected feature. You can specify a smoothing window, which is the number of neighbouring values that will be summed either side of each point. The average of this sum will become the new value for that point.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+                        </CheckBox>
                         <Region HBox.hgrow="ALWAYS"/>
                         <Label fx:id="lbSmoothOrder" textAlignment="RIGHT">
-                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                            <tooltip>
+                                <Tooltip text="The order in which the preprocessor was applied.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+
+                            <font><Font name="System Bold" size="18.0"/></font>
                         </Label>
                     </HBox>
                     <VBox fx:id="vbSmoothData" visible="false" managed="false">
@@ -85,12 +99,25 @@
                     </VBox>
                     <Separator/>
 
-
+                    <!-- HANDLE MISSING VALUES -->
                     <HBox>
-                        <CheckBox fx:id="cbHandleMissingValues" text="Handle missing values" disable="true"/>
+                        <CheckBox fx:id="cbHandleMissingValues" text="Handle missing values" disable="true">
+                            <tooltip>
+                                <Tooltip wrapText="true" prefWidth="500"
+                                         text="Removes all null (empty) elements from the selected feature, and replaces them with the selected option in the drop down list.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+                        </CheckBox>
                         <Region HBox.hgrow="ALWAYS"/>
                         <Label fx:id="lbHandleMissingValuesOrder" textAlignment="RIGHT">
-                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                            <tooltip>
+                                <Tooltip text="The order in which the preprocessor was applied.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+
+                            <font><Font name="System Bold" size="18.0"/></font>
                         </Label>
                     </HBox>
                     <VBox fx:id="vbHandleMissingValues" visible="false" managed="false">
@@ -111,11 +138,25 @@
                     </VBox>
                     <Separator/>
 
+                    <!-- NORMALISE SCALE -->
                     <HBox>
-                        <CheckBox fx:id="cbNormalise" text="Normalise scale" disable="true"/>
+                        <CheckBox fx:id="cbNormalise" text="Normalise scale" disable="true">
+                            <tooltip>
+                                <Tooltip wrapText="true" prefWidth="500"
+                                         text="Scales all values within the selected feature to be between the specified minimum and maximum values.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+                        </CheckBox>
                         <Region HBox.hgrow="ALWAYS"/>
                         <Label fx:id="lbNormaliseOrder" textAlignment="RIGHT">
-                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                            <tooltip>
+                                <Tooltip text="The order in which the preprocessor was applied.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+
+                            <font><Font name="System Bold" size="18.0"/></font>
                         </Label>
                     </HBox>
                     <VBox fx:id="vbNormalise" visible="false" managed="false">
@@ -130,11 +171,25 @@
                     </VBox>
                     <Separator/>
 
+                    <!-- REMOVE OUTLIERS -->
                     <HBox>
-                        <CheckBox fx:id="cbRemoveOutliers" text="Remove outliers" disable="true"/>
+                        <CheckBox fx:id="cbRemoveOutliers" text="Remove outliers" disable="true">
+                            <tooltip>
+                                <Tooltip wrapText="true" prefWidth="500"
+                                         text="Removes all points in the selected feature that are considered outliers. You can specify a threshold value that controls the tolerance with which outliers are calculated. High threshold = less points considered outliers. Low threshold = more points considered outliers.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+                        </CheckBox>
                         <Region HBox.hgrow="ALWAYS"/>
                         <Label fx:id="lbRemoveOutliersOrder" textAlignment="RIGHT">
-                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                            <tooltip>
+                                <Tooltip text="The order in which the preprocessor was applied.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+
+                            <font><Font name="System Bold" size="18.0"/></font>
                         </Label>
                     </HBox>
                     <VBox fx:id="vbRemoveOutliers" visible="false" managed="false">
@@ -145,11 +200,25 @@
                     </VBox>
                     <Separator/>
 
+                    <!-- OFFSET DATA -->
                     <HBox>
-                        <CheckBox fx:id="cbOffset" text="Offset data" disable="true"/>
+                        <CheckBox fx:id="cbOffset" text="Offset data" disable="true">
+                            <tooltip>
+                                <Tooltip wrapText="true" prefWidth="500"
+                                         text="Shifts all values within the selected feature by the given offset value.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+                        </CheckBox>
                         <Region HBox.hgrow="ALWAYS"/>
                         <Label fx:id="lbOffsetValuesOrder" textAlignment="RIGHT">
-                            <tooltip><Tooltip text="The order in which the preprocessor was applied."/></tooltip>
+                            <tooltip>
+                                <Tooltip text="The order in which the preprocessor was applied.">
+                                    <font><Font size="12.0"/></font>
+                                </Tooltip>
+                            </tooltip>
+
+                            <font><Font name="System Bold" size="18.0"/></font>
                         </Label>
                     </HBox>
                     <VBox fx:id="vbOffset" visible="false" managed="false">

--- a/client/src/main/resources/views/workspace/ReportView.fxml
+++ b/client/src/main/resources/views/workspace/ReportView.fxml
@@ -34,10 +34,11 @@
 <?import javafx.stage.Screen?>
 <?import org.iconic.control.WorkspaceTab?>
 <?import java.lang.String?>
-<WorkspaceTab text="   Reports" tabType="SEARCH"
+<WorkspaceTab text="   Reports" tabType="REPORT"
               xmlns="http://javafx.com/javafx"
               xmlns:fx="http://javafx.com/fxml"
-              fx:controller="org.iconic.workspace.WorkspaceController">
+              fx:controller="org.iconic.workspace.WorkspaceController"
+              disable="true">
 
     <!-- Define the primary screen so we can use percentage based widths -->
     <fx:define>


### PR DESCRIPTION
**Changes**
Many minor GUI changes:
- 'Reports' tab is now permanently disabled
- Made preprocessing order labels bold and increased font size
- Added hover tooltips to all preprocessors
- Added hover tooltips to all CGP/GEP options on the define search page
- Adding a new search now defaults to CGP
- Now only one option for mutator and crossover techniques
- Removed unimplemented error metrics
- 'Input data' tab is now disabled when a search is selected


