### PR TITLE
Search Pausing

### DIFF
--- a/client/src/main/java/org/iconic/project/definition/DefineSearchController.java
+++ b/client/src/main/java/org/iconic/project/definition/DefineSearchController.java
@@ -48,6 +48,7 @@ import org.iconic.project.ProjectModel;
 import org.iconic.project.ProjectService;
 import org.iconic.project.dataset.DatasetModel;
 import org.iconic.project.search.config.CgpConfigurationModel;
+import org.iconic.project.search.io.SearchExecutor;
 import org.iconic.views.ViewService;
 import org.iconic.project.search.config.SearchConfigurationModel;
 import org.iconic.workspace.WorkspaceService;
@@ -231,7 +232,10 @@ public class DefineSearchController implements Initializable, DefineSearchServic
             return;
         }
 
-        SearchConfigurationModel configModel = (SearchConfigurationModel) item;
+        SearchConfigurationModel search = (SearchConfigurationModel) item;
+
+        // Stop any existing searches if we change the dataset
+        search.getSearchExecutor().ifPresent(SearchExecutor::stop);
 
         if (newValue != null) {
             // Get the new dataset
@@ -252,7 +256,7 @@ public class DefineSearchController implements Initializable, DefineSearchServic
             }
         }
 
-        configModel.setDatasetModel(newValue);
+        search.setDatasetModel(newValue);
         loadFunction();
     }
 

--- a/client/src/main/java/org/iconic/project/results/ResultsController.java
+++ b/client/src/main/java/org/iconic/project/results/ResultsController.java
@@ -204,7 +204,8 @@ public class ResultsController implements Initializable {
             // This is all the chromosomes with the same size of 'x'
             for (Chromosome<?> chromosome : chromosomeList) {
                 // Chromosome simplified expression
-                String simplifiedChromosome = chromosome.simplifyExpression(chromosome.getExpression(chromosome.toString(), new ArrayList<>(model.getEnabledPrimitives()), true));
+                String simplifiedChromosome = chromosome.simplifyExpression(
+                        chromosome.getExpression(chromosome.toString(), new ArrayList<>(model.getPrimitives().keySet()), true));
 
                 // If the chromosome equals the selected chromosome
                 if (simplifiedChromosome.equals(row.getSolution())) {
@@ -261,7 +262,7 @@ public class ResultsController implements Initializable {
         for (Map.Entry<Integer, List<Chromosome<?>>> entry : storage.getSolutions().entrySet()) {
             Chromosome<?> result = entry.getValue().get(0);
             resultDisplays.add(new ResultDisplay(result.getSize(), result.getFitness(), result.simplifyExpression(
-                    result.getExpression(result.toString(), new ArrayList<>(model.getEnabledPrimitives()), true)
+                    result.getExpression(result.toString(), new ArrayList<>(model.getPrimitives().keySet()), true)
             )));
         }
 

--- a/client/src/main/java/org/iconic/project/search/config/CgpConfigurationModel.java
+++ b/client/src/main/java/org/iconic/project/search/config/CgpConfigurationModel.java
@@ -95,7 +95,7 @@ public class CgpConfigurationModel extends SearchConfigurationModel {
         ea.initialisePopulation(getPopulationSize());
 
         SearchExecutor<CartesianChromosome<Double>> searchExecutor =
-                new SearchExecutor<>(getDatasetModel().get(), getEnabledPrimitives(), getNumGenerations());
+                new SearchExecutor<>(getDatasetModel().get(), getEnabledPrimitives(), this);
         searchExecutor.setEvolutionaryAlgorithm(ea);
 
         return searchExecutor;
@@ -135,46 +135,6 @@ public class CgpConfigurationModel extends SearchConfigurationModel {
     @Override
     protected boolean isValid() {
         return getDatasetModel().isPresent();
-    }
-
-    /**
-     * Sets the number of outputs of this search configuration.
-     *
-     * @param numOutputs Must be between one and positive infinity, inclusive.
-     */
-    public void setNumOutputs(int numOutputs) {
-        setChanged(true);
-        this.numOutputs.set(numOutputs);
-    }
-
-    /**
-     * Sets the number of columns of this search configuration.
-     *
-     * @param numColumns Must be between one and positive infinity, inclusive.
-     */
-    public void setNumColumns(int numColumns) {
-        setChanged(true);
-        this.numColumns.set(numColumns);
-    }
-
-    /**
-     * Sets the number of rows of this search configuration.
-     *
-     * @param numRows Must be between one and positive infinity, inclusive.
-     */
-    public void setNumRows(int numRows) {
-        setChanged(true);
-        this.numRows.set(numRows);
-    }
-
-    /**
-     * Sets the number of levels back of this search configuration.
-     *
-     * @param numLevelsBack Must be between one and positive infinity, inclusive.
-     */
-    public void setNumLevelsBack(int numLevelsBack) {
-        setChanged(true);
-        this.numLevelsBack.set(numLevelsBack);
     }
 
     /**

--- a/client/src/main/java/org/iconic/project/search/config/GepConfigurationModel.java
+++ b/client/src/main/java/org/iconic/project/search/config/GepConfigurationModel.java
@@ -83,7 +83,7 @@ public class GepConfigurationModel extends SearchConfigurationModel {
         ea.initialisePopulation(getPopulationSize());
 
         SearchExecutor<ExpressionChromosome<Double>> searchExecutor =
-                new SearchExecutor<>(getDatasetModel().get(), getEnabledPrimitives(), getNumGenerations());
+                new SearchExecutor<>(getDatasetModel().get(), getEnabledPrimitives(), this);
         searchExecutor.setEvolutionaryAlgorithm(ea);
 
         return searchExecutor;
@@ -102,16 +102,6 @@ public class GepConfigurationModel extends SearchConfigurationModel {
      */
     public int getHeadLength() {
         return headLength.get();
-    }
-
-    /**
-     * Sets the head length of this search configuration.
-     *
-     * @param headLength Must be between one and positive infinity, inclusive.
-     */
-    public void setHeadLength(int headLength) {
-        setChanged(true);
-        this.headLength.set(headLength);
     }
 
     /**

--- a/client/src/main/java/org/iconic/project/search/config/SearchConfigurationModel.java
+++ b/client/src/main/java/org/iconic/project/search/config/SearchConfigurationModel.java
@@ -22,6 +22,7 @@ import javafx.scene.control.Control;
 import javafx.util.converter.NumberStringConverter;
 import lombok.NonNull;
 import org.controlsfx.glyphfont.FontAwesome;
+import org.iconic.ea.EvolutionaryAlgorithm;
 import org.iconic.ea.operator.primitive.*;
 import org.iconic.project.Displayable;
 import org.iconic.project.dataset.DatasetModel;
@@ -107,9 +108,6 @@ public abstract class SearchConfigurationModel implements Displayable {
 
         // When a property is changed set the state of the configuration to changed
         this.populationSizeProperty().addListener(obs -> setChanged(true));
-        this.numGenerationsProperty().addListener(obs -> setChanged(true));
-        this.crossoverRateProperty().addListener(obs -> setChanged(true));
-        this.mutationRateProperty().addListener(obs -> setChanged(true));
     }
 
     /**
@@ -289,52 +287,12 @@ public abstract class SearchConfigurationModel implements Displayable {
     }
 
     /**
-     * Sets the mutation rate of this search configuration.
-     *
-     * @param mutationRate Must be between zero and one, inclusive.
-     */
-    public void setMutationRate(double mutationRate) {
-        setChanged(true);
-        this.mutationRate.set(mutationRate);
-    }
-
-    /**
-     * Sets the crossover rate of this search configuration.
-     *
-     * @param crossoverRate Must be between zero and one, inclusive.
-     */
-    public void setCrossoverRate(double crossoverRate) {
-        setChanged(true);
-        this.crossoverRate.set(crossoverRate);
-    }
-
-    /**
      * Sets the changed status of this search configuration.
      *
      * @param changed If true this configuration model will be updated the next time it's evaluated.
      */
     public void setChanged(boolean changed) {
         this.changed = changed;
-    }
-
-    /**
-     * Sets the number of generations of this search configuration.
-     *
-     * @param numGenerations If the number of generations is less than one it's treated as infinity.
-     */
-    public void setNumGenerations(int numGenerations) {
-        setChanged(true);
-        this.numGenerations.set(numGenerations);
-    }
-
-    /**
-     * Sets the population size of this search configuration.
-     *
-     * @param populationSize Must be greater than zero.
-     */
-    public void setPopulationSize(int populationSize) {
-        setChanged(true);
-        this.populationSize.set(populationSize);
     }
 
     /**

--- a/client/src/main/java/org/iconic/project/search/io/SearchExecutor.java
+++ b/client/src/main/java/org/iconic/project/search/io/SearchExecutor.java
@@ -17,9 +17,7 @@ package org.iconic.project.search.io;
 
 import javafx.application.Platform;
 import javafx.beans.property.ListProperty;
-import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleListProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.chart.XYChart;
@@ -38,7 +36,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-import static javafx.collections.FXCollections.emptyObservableList;
+import static org.iconic.project.search.io.SearchState.*;
 
 /**
  * <p>A model for evolutionary searches, it maintains a dataset, data manager, and a trainer
@@ -48,6 +46,9 @@ import static javafx.collections.FXCollections.emptyObservableList;
  */
 @Log4j2
 public class SearchExecutor<T extends Chromosome<Double>> implements Runnable {
+
+    private static final long PAUSE_SLEEP = 100;
+
     private final XYChart.Series<Number, Number> plots;
     private final DatasetModel datasetModel;
     private final ObservableList<String> _updates;
@@ -56,11 +57,13 @@ public class SearchExecutor<T extends Chromosome<Double>> implements Runnable {
     private final SolutionStorage<T> solutionStorage; // Stores the solutions found
     private final List<FunctionalPrimitive<Double, Double>> primitives;
     private EvolutionaryAlgorithm<T, Double> evolutionaryAlgorithm;
-    private boolean running;
 
+    private transient SearchState state;
+
+    private transient Long lastUpdateTime;
     private transient Long startTime;
     private transient Long elapsedDuration;
-    private transient Long lastImproveTime;
+    private transient Long timeSinceImprovement;
     private transient int improvedCount;
     private transient int generation;
 
@@ -80,7 +83,7 @@ public class SearchExecutor<T extends Chromosome<Double>> implements Runnable {
         this.plots = new XYChart.Series<>();
         this._updates = FXCollections.observableArrayList();
         this.updates = new SimpleListProperty<>(_updates);
-        this.running = false;
+        this.state = STOPPED;
         this.plots.setName(this.datasetModel.getName());
         this.primitives = primitives;
         this.solutionStorage = new SolutionStorage<>();
@@ -93,55 +96,80 @@ public class SearchExecutor<T extends Chromosome<Double>> implements Runnable {
      */
     @Override
     public void run() {
-        setRunning(true);
+        setState(RUNNING);
         setup();
         log.debug("Starting search");
+        addUpdate("Starting...");
+
         Comparator<Chromosome<Double>> comparator = Comparator.comparing(Chromosome::getFitness);
 
-        while (isRunning()) {
-            try {
-                Chromosome<Double> bestCandidate = getEvolutionaryAlgorithm().getChromosomes()
-                        .stream().min(comparator).get();
-                addPlot(0, bestCandidate);
-                addUpdate("Starting...");
-                addChromosomeUpdate(bestCandidate);
+        try {
+            Chromosome<Double> bestCandidate = getEvolutionaryAlgorithm().getChromosomes()
+                    .stream().min(comparator).get();
+            addPlot(0, bestCandidate);
+            addChromosomeUpdate(bestCandidate);
 
-                for (generation = 1; (generation <= getNumGenerations() || getNumGenerations() == 0) && isRunning(); ++generation) {
-                    List<T> oldPopulation = getEvolutionaryAlgorithm().getChromosomes();
-                    List<T> newPopulation = getEvolutionaryAlgorithm().evolve(oldPopulation);
-                    getEvolutionaryAlgorithm().setChromosomes(newPopulation);
+            for (generation = 1; (generation <= getNumGenerations() || getNumGenerations() <= 0); ++generation) {
 
-                    // Evaluate the new population of solutions and store the best ones
-                    solutionStorage.evaluate(newPopulation);
-
-                    T newBestCandidate = getEvolutionaryAlgorithm().getChromosomes().stream().min(comparator).get();
-                    Objective<?> objective = getEvolutionaryAlgorithm().getObjective();
-
-                    // Only add a new plot point if the fitness value improves
-                    boolean newCandidate = objective.isNotWorse(
-                            newBestCandidate.getFitness(),
-                            bestCandidate.getFitness()
-                    ) && !objective.isEqual(
-                            newBestCandidate.getFitness(),
-                            bestCandidate.getFitness()
-                    );
-
-                    if (newCandidate) {
-                        bestCandidate = newBestCandidate;
-                        addChromosomeUpdate(bestCandidate);
-                    }
-                    elapsedDuration = System.currentTimeMillis() - startTime;
+                // Not running? Exit it.
+                if (getState() == STOPPED) {
+                    break;
                 }
-            } catch (Exception ex) {
-                log.error("{}: ", ex::getMessage);
-                Arrays.stream(ex.getStackTrace()).forEach(log::error);
-            } finally {
-                addUpdate("Finished!");
-                setRunning(false);
-                elapsedDuration = System.currentTimeMillis() - startTime;
-                log.debug("Stopping search");
+                // Paused? We'll wait.
+                while (getState() == PAUSED) {
+                    Thread.sleep(PAUSE_SLEEP);
+                }
+                startTime = System.currentTimeMillis();
+                lastUpdateTime = startTime;
+
+                List<T> oldPopulation = getEvolutionaryAlgorithm().getChromosomes();
+                List<T> newPopulation = getEvolutionaryAlgorithm().evolve(oldPopulation);
+                getEvolutionaryAlgorithm().setChromosomes(newPopulation);
+
+                // Evaluate the new population of solutions and store the best ones
+                solutionStorage.evaluate(newPopulation);
+
+                T newBestCandidate = getEvolutionaryAlgorithm().getChromosomes().stream().min(comparator).get();
+                Objective<?> objective = getEvolutionaryAlgorithm().getObjective();
+
+                // Only add a new plot point if the fitness value improves
+                boolean newCandidate = objective.isNotWorse(
+                        newBestCandidate.getFitness(),
+                        bestCandidate.getFitness()
+                ) && !objective.isEqual(
+                        newBestCandidate.getFitness(),
+                        bestCandidate.getFitness()
+                );
+
+                updateTimes();
+                if (newCandidate) {
+                    bestCandidate = newBestCandidate;
+                    addChromosomeUpdate(bestCandidate);
+                }
             }
+        } catch (Exception ex) {
+            log.error("{}: ", ex::getMessage);
+            Arrays.stream(ex.getStackTrace()).forEach(log::error);
+        } finally {
+            updateTimes();
+            log.debug("Stopping search");
+            addUpdate("Finished!");
+            setState(STOPPED);
         }
+    }
+
+    /**
+     * Pauses the current search
+     */
+    public void pause() {
+        setState(PAUSED);
+    }
+
+    /**
+     * Stops any ongoing search.
+     */
+    public void stop() {
+        setState(STOPPED);
     }
 
     private void addChromosomeUpdate(Chromosome<?> chromosome) {
@@ -168,14 +196,24 @@ public class SearchExecutor<T extends Chromosome<Double>> implements Runnable {
      */
     private void setup() {
         startTime = System.currentTimeMillis();
+        lastUpdateTime = startTime;
         elapsedDuration = 0L;
-        lastImproveTime = startTime;
+        timeSinceImprovement = 0L;
     }
 
     private void setImproved(Chromosome<?> bestCandidate) {
         addPlot(getGeneration(), bestCandidate);
-        lastImproveTime = System.currentTimeMillis();
+        timeSinceImprovement = 0L;
         improvedCount++;
+    }
+
+    private void updateTimes() {
+        long current = System.currentTimeMillis();
+        long diff = current - lastUpdateTime;
+        lastUpdateTime = current;
+        elapsedDuration += current - startTime;
+        timeSinceImprovement += diff;
+        startTime = null;
     }
 
     /**
@@ -194,15 +232,7 @@ public class SearchExecutor<T extends Chromosome<Double>> implements Runnable {
     }
 
     /**
-     * Stops any ongoing search.
-     */
-    public void stop() {
-        setRunning(false);
-    }
-
-    /**
      * Returns the dataset that's being trained on.
-     *
      * @return The dataset that this search executor is training on.
      */
     public DatasetModel getDatasetModel() {
@@ -221,13 +251,13 @@ public class SearchExecutor<T extends Chromosome<Double>> implements Runnable {
         return updates;
     }
 
-    public boolean isRunning() {
-        return running;
+    public SearchState getState() {
+        return state;
     }
 
     @Synchronized
-    public void setRunning(boolean running) {
-        this.running = running;
+    public void setState(SearchState state) {
+        this.state = state;
     }
 
     public XYChart.Series<Number, Number> getPlots() {
@@ -254,16 +284,16 @@ public class SearchExecutor<T extends Chromosome<Double>> implements Runnable {
         return solutionStorage;
     }
 
-    public Long getStartTime() {
-        return startTime;
+    public Long getLastUpdateTime() {
+        return lastUpdateTime;
     }
 
     public Long getElapsedDuration() {
         return elapsedDuration;
     }
 
-    public Long getLastImproveTime() {
-        return lastImproveTime;
+    public Long getTimeSinceImprovement() {
+        return timeSinceImprovement;
     }
 
     public Long getAverageImproveDuration() {

--- a/client/src/main/java/org/iconic/project/search/io/SearchState.java
+++ b/client/src/main/java/org/iconic/project/search/io/SearchState.java
@@ -1,0 +1,10 @@
+package org.iconic.project.search.io;
+
+/**
+ * What state a search is in
+ */
+public enum SearchState {
+    RUNNING,
+    PAUSED,
+    STOPPED
+}


### PR DESCRIPTION
**Changes**
* Searches can now be paused and resumed from the current spot
* When a search is paused, you are able to change the mutation rate, crossover rate, number of generations, and which blocks are enabled/disabled
* Statistics update accordingly, such as time elapsed
* Fix a memory issue where if a the dataset is changed for a search configuration whilst a search is already running, the search doesn't stop.
