### PR TITLE
Change graph export format from PDF to PNG and remove axis scaling

### DIFF
--- a/api/src/main/java/org/iconic/ea/strategies/gsemo/GSEMO.java
+++ b/api/src/main/java/org/iconic/ea/strategies/gsemo/GSEMO.java
@@ -70,11 +70,11 @@ public class GSEMO<R extends Chromosome<T>, T extends Comparable<T>>
         // Exactly one parent is required
         final R parent = getSelector(0).apply(newPopulation);
 
-        // Create a single offspring by performing mutation on the parent
+        // Create a single offspring by performing crossover and mutation on the parent
         R offspring = mutate((R) parent.clone());
 
-        // Continue mutating the offspring based on its parent's length
-        // reducing the probability of mutation with each attempt
+        // Continue evolving the offspring based on its parent's length
+        // reducing the probability of evolution with each attempt
         for (int j = 2; j <= parent.getSize(); ++j) {
             if ((1. / (double) j) >= ThreadLocalRandom.current().nextDouble()) {
                 offspring = mutate(offspring);

--- a/cli/src/main/java/org/iconic/utils/GraphWriter.java
+++ b/cli/src/main/java/org/iconic/utils/GraphWriter.java
@@ -16,6 +16,7 @@
 package org.iconic.utils;
 
 import org.iconic.ea.chromosome.Chromosome;
+import org.knowm.xchart.BitmapEncoder;
 import org.knowm.xchart.VectorGraphicsEncoder;
 import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.series.Series;
@@ -25,6 +26,7 @@ import java.io.IOException;
 
 public abstract class GraphWriter<T extends Series> {
     private boolean axesTruncated;
+    private boolean axesLogarithmic;
 
     /**
      * Constructs a new GraphWriter that will truncate outliers from its axes by default.
@@ -48,9 +50,9 @@ public abstract class GraphWriter<T extends Series> {
     public void export(final String chartTitle, final String directory, final String fileName) throws IOException {
         Chart<?, ?> chart = draw();
         chart.setTitle(chartTitle);
-        VectorGraphicsEncoder.saveVectorGraphic(
+        BitmapEncoder.saveBitmap(
                 chart, directory + "//" + fileName,
-                VectorGraphicsEncoder.VectorGraphicsFormat.PDF
+                BitmapEncoder.BitmapFormat.PNG
         );
     }
 
@@ -72,9 +74,23 @@ public abstract class GraphWriter<T extends Series> {
     }
 
     /**
+     * @return True if axes of  the graph written by the GraphWriter will use logarithmic scaling.
+     */
+    public boolean isAxesLogarithmic() {
+        return axesLogarithmic;
+    }
+
+    /**
      * @param truncate True if the axes of the graph being written should remove outliers.
      */
     public void setAxesTruncated(boolean truncate) {
         this.axesTruncated = truncate;
+    }
+
+    /**
+     * @param logarithmic True if the axes of the graph being written should use logarithmic scaling.
+     */
+    public void setAxesLogarithmic(boolean logarithmic) {
+        this.axesLogarithmic = logarithmic;
     }
 }

--- a/cli/src/main/java/org/iconic/utils/XYGraphWriter.java
+++ b/cli/src/main/java/org/iconic/utils/XYGraphWriter.java
@@ -179,7 +179,10 @@ public class XYGraphWriter extends GraphWriter<XYSeries> {
                     .theme(Styler.ChartTheme.Matlab).build();
             chart.getStyler().setChartTitleVisible(true);
             chart.getStyler().setMarkerSize(12);
-            chart.getStyler().setXAxisLogarithmic(true);
+
+            if (isAxesLogarithmic()) {
+                chart.getStyler().setXAxisLogarithmic(true);
+            }
         }
 
         return chart;


### PR DESCRIPTION
 **Changes** 
- [ x ] Export graphs as PNGs instead of PDFs to vastly reduce export times.
- [ x ] Disable logarithmic scaling of the axes of the solution fit plot.