### PR TITLE
Let users specify what primitives to use from the CLI and fixes a bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 #### CLI
 * Graph output changed from PDF to PNG, bringing speed improvements
 * Logarithmic scaling of axes in the solution fit plot has been disabled
+* The ability to choose building blocks (primitives) has been implemented
 
 #### General
 * Added link to repository to the “About Iconic Workbench” dialog in the Help section of the menu bar

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ allprojects {
         options.compilerArgs << "-Xlint:all" << "-Xlint:-processing"
     }
     dependencies {
+        compile group: 'io.github.classgraph', name: 'classgraph', version: '4.4.12'
         compile group: 'org.projectlombok', name: 'lombok', version: '1.16.16'
         compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.0'
         compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'

--- a/cli/src/main/java/org/iconic/Client.java
+++ b/cli/src/main/java/org/iconic/Client.java
@@ -35,6 +35,7 @@ import org.iconic.ea.operator.primitive.*;
 import org.iconic.ea.strategies.MultiObjectiveEvolutionaryAlgorithm;
 import org.iconic.ea.strategies.gsemo.GSEMO;
 import org.iconic.io.cli.ArgsConverterFactory;
+import org.iconic.io.cli.PrimitiveTypeConverter;
 import org.iconic.utils.GraphWriter;
 import org.iconic.utils.SeriesWriter;
 import org.iconic.utils.XYGraphWriter;
@@ -72,6 +73,21 @@ public class Client {
         // Check if the user passed in the help flag
         if (client.getArgs().isHelp()) {
             client.usage();
+            return;
+        }
+
+        // Check if the user wants to see all of the available primitives
+        if (client.getArgs().isListPrimitives()) {
+            // Print each primitive and its description on its own line
+            log.info(
+                    "Primitives:\n\t{}",
+                    String.join("\n\n\t", new PrimitiveTypeConverter().getPrimitives().values()
+                        .stream()
+                            .map(v -> String.format("%s", v.getDescription().replace("\n", "\n\t")))
+                            .collect(Collectors.toList())
+                        )
+            );
+            return;
         }
 
         // Check if the user passed in an input file
@@ -93,9 +109,11 @@ public class Client {
             int columns = client.getArgs().getColumns();
             int rows = client.getArgs().getRows();
             int levelsBack = client.getArgs().getLevelsBack();
+            List<FunctionalPrimitive<Double, Double>> blocks = client.getArgs().getPrimitives();
 
             log.info("Feature Size: {}", () -> featureSize - 1);
             log.info("Sample Size: {}", () -> sampleSize);
+            log.info("Primitives: {}", () -> blocks);
 
             // Create a supplier for Gene Cartesian Programming chromosomes
             List<String> inputs = new ArrayList<>(featureSize - 1);
@@ -112,10 +130,7 @@ public class Client {
             );
 
             // Add all of the functions the chromosomes can use
-            supplier.addFunction(Arrays.asList(
-                    new Addition(), new Subtraction(), new Multiplication(), new Root(),
-                    new Division(), new Power(), new Exponential(), new Sin(), new Cos()
-            ));
+            supplier.addFunction(blocks);
 
             final int numConstants = 100;
             final int min = -100;

--- a/cli/src/main/java/org/iconic/Client.java
+++ b/cli/src/main/java/org/iconic/Client.java
@@ -111,9 +111,14 @@ public class Client {
             int levelsBack = client.getArgs().getLevelsBack();
             List<FunctionalPrimitive<Double, Double>> blocks = client.getArgs().getPrimitives();
 
+            // If no primitives are specified default to all of them
+            if (blocks == null || blocks.size() < 1) {
+                blocks = new ArrayList<>(new PrimitiveTypeConverter().getPrimitives().values());
+            }
+
             log.info("Feature Size: {}", () -> featureSize - 1);
             log.info("Sample Size: {}", () -> sampleSize);
-            log.info("Primitives: {}", () -> blocks);
+            log.info("Primitives: {}", blocks);
 
             // Create a supplier for Gene Cartesian Programming chromosomes
             List<String> inputs = new ArrayList<>(featureSize - 1);

--- a/cli/src/main/java/org/iconic/Client.java
+++ b/cli/src/main/java/org/iconic/Client.java
@@ -132,19 +132,6 @@ public class Client {
             // Add all of the functions the chromosomes can use
             supplier.addFunction(blocks);
 
-            final int numConstants = 100;
-            final int min = -100;
-            final int max = 100;
-            final List<FunctionalPrimitive<Double, Double>> constants = new ArrayList<>(numConstants);
-
-            while (constants.size() < numConstants) {
-                constants.add(new Constant<>(ThreadLocalRandom.current().nextDouble(
-                        min, max
-                )));
-            }
-
-            supplier.addFunction(constants);
-
             final int generations = client.getArgs().getGenerations();
             final Set<Chromosome<Double>> nonDominatedFinal = new LinkedHashSet<>();
             final List<Set<Chromosome<Double>>> nonDominatedAll = new ArrayList<>(generations);

--- a/cli/src/main/java/org/iconic/io/cli/ArgsConverterFactory.java
+++ b/cli/src/main/java/org/iconic/io/cli/ArgsConverterFactory.java
@@ -16,104 +16,75 @@
 package org.iconic.io.cli;
 
 import com.beust.jcommander.Parameter;
+import lombok.Getter;
 import org.iconic.ea.EvolutionaryAlgorithmType;
+import org.iconic.ea.operator.primitive.FunctionalPrimitive;
+
+import java.util.List;
 
 public class ArgsConverterFactory {
+    @Getter
     @Parameter(names = {"--algorithm", "-a"}, description = "The type of evolutionary algorithm to use")
     private EvolutionaryAlgorithmType eaType;
 
+    @Getter
     @Parameter(names = {"--input", "-i"}, required = true, description = "The dataset to use")
     private String input;
 
+    @Getter
     @Parameter(names= {"--generations", "-g"}, required = true, description = "The number of generations to evolve")
     private int generations;
 
+    @Getter
     @Parameter(names= {"--population", "-p"}, required = true, description = "The population size of the candidates")
     private int population;
 
+    @Getter
     @Parameter(names= {"--crossoverProbability", "-cP"}, required = false, description = "The crossover probability for each candidate")
     private double crossoverProbability = 0.2;
 
+    @Getter
     @Parameter(names= {"--mutationProbability", "-mP"}, required = false, description = "The mutation probability for each candidate")
     private double mutationProbability = 0.1;
 
+    @Getter
     @Parameter(names= {"--outputs"}, required = true, description = "The number of outputs, if the chosen algorithm can't support multiple outputs this argument will be ignored")
     private int outputs = 1;
 
+    @Getter
     @Parameter(names= {"--columns"}, description = "The number of columns if supported by the chosen algorithm")
     private int columns = 1;
 
+    @Getter
     @Parameter(names= {"--rows"}, description = "The number of rows if supported by the chosen algorithm")
     private int rows = 1;
 
+    @Getter
     @Parameter(names= {"--levelsBack"}, description = "The number of levels back if supported by the chosen algorithm")
     private int levelsBack = 1;
 
+    @Getter
     @Parameter(names= {"--repeat", "-r"}, description = "The number of times to repeat the experiment. The results will be collated")
     private int repetitions = 1;
 
+    @Getter
     @Parameter(names = {"--help", "-h"}, help = true)
     private boolean help;
 
+    @Getter
     @Parameter(names = {"--graph"}, description = "Graph the solutions if true")
     private boolean graph;
 
+    @Getter
     @Parameter(names = {"--csv"}, description = "Export the pareto-optimal front to a CSV file if true")
     private boolean csv;
 
-    public EvolutionaryAlgorithmType getEaType() {
-        return eaType;
-    }
+    @Getter
+    @Parameter(names = {"--primitives"}, required = true, description = "The primitives to use in the search",
+     converter = PrimitiveTypeConverter.class)
+    private List<FunctionalPrimitive<Double, Double>> primitives;
 
-    public String getInput() {
-        return input;
-    }
-
-    public boolean isHelp() {
-        return help;
-    }
-
-    public int getGenerations() {
-        return generations;
-    }
-
-    public int getPopulation() {
-        return population;
-    }
-
-    public double getMutationProbability() {
-        return mutationProbability;
-    }
-
-    public double getCrossoverProbability() {
-        return crossoverProbability;
-    }
-
-    public int getOutputs () {
-        return outputs;
-    }
-
-    public int getColumns () {
-        return columns;
-    }
-
-    public int getRows() {
-        return rows;
-    }
-
-    public int getLevelsBack() {
-        return levelsBack;
-    }
-
-    public boolean isGraph() {
-        return graph;
-    }
-
-    public boolean isCsv() {
-        return csv;
-    }
-
-    public int getRepetitions() {
-        return repetitions;
-    }
+    @Getter
+    @Parameter(names = {"--listPrimitives"}, description = "List all of the primitives that can be used in the search")
+    private boolean listPrimitives;
 }

--- a/cli/src/main/java/org/iconic/io/cli/ArgsConverterFactory.java
+++ b/cli/src/main/java/org/iconic/io/cli/ArgsConverterFactory.java
@@ -80,11 +80,11 @@ public class ArgsConverterFactory {
     private boolean csv;
 
     @Getter
-    @Parameter(names = {"--primitives"}, required = true, description = "The primitives to use in the search",
+    @Parameter(names = {"--primitives"}, description = "The primitives to use in the search",
      converter = PrimitiveTypeConverter.class)
     private List<FunctionalPrimitive<Double, Double>> primitives;
 
     @Getter
-    @Parameter(names = {"--listPrimitives"}, description = "List all of the primitives that can be used in the search")
+    @Parameter(names = {"--listPrimitives"}, help = true, description = "List all of the primitives that can be used in the search")
     private boolean listPrimitives;
 }

--- a/cli/src/main/java/org/iconic/io/cli/PrimitiveTypeConverter.java
+++ b/cli/src/main/java/org/iconic/io/cli/PrimitiveTypeConverter.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2018 Iconic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.iconic.io.cli;
+
+import com.beust.jcommander.IStringConverter;
+import io.github.classgraph.*;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import org.iconic.ea.EvolutionaryAlgorithmType;
+import org.iconic.ea.operator.primitive.FunctionalPrimitive;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Log4j2
+public class PrimitiveTypeConverter implements IStringConverter<FunctionalPrimitive<Double, Double>> {
+    @Getter
+    final private Map<String, FunctionalPrimitive<Double, Double>> primitives;
+
+    @SuppressWarnings("unchecked")
+    public PrimitiveTypeConverter() {
+        super();
+        primitives = new LinkedHashMap<>();
+        final String pkg = "org.iconic.ea.operator.primitive";
+        final String superclass = pkg + ".ArithmeticPrimitive";
+        final String[] exclude = new String[]{
+                superclass
+        };
+
+        try (ScanResult scanResult =
+                     new ClassGraph()
+                             .enableAllInfo()
+                             .whitelistPackages(pkg)
+                             .blacklistClasses(exclude)
+                             .scan()
+        ) {
+            for (ClassInfo classInfo : scanResult.getSubclasses(superclass)) {
+                FunctionalPrimitive<Double, Double> primitive =
+                        (FunctionalPrimitive<Double, Double>) classInfo.loadClass().newInstance();
+                primitives.put(primitive.getSymbol(), primitive);
+            }
+        } catch (IllegalAccessException | InstantiationException ex) {
+            log.error("{}: {}", ex::getMessage, ex::getCause);
+        }
+    }
+
+    @Override
+    public FunctionalPrimitive<Double, Double> convert(String value) {
+        return primitives.get(value);
+    }
+}

--- a/cli/src/main/java/org/iconic/io/cli/PrimitiveTypeConverterFactory.java
+++ b/cli/src/main/java/org/iconic/io/cli/PrimitiveTypeConverterFactory.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018 Iconic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.iconic.io.cli;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.IStringConverterFactory;
+import org.iconic.ea.EvolutionaryAlgorithmType;
+import org.iconic.ea.operator.primitive.FunctionalPrimitive;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class PrimitiveTypeConverterFactory implements IStringConverterFactory {
+    @Override
+    public Class<? extends IStringConverter<?>> getConverter(Class forType) {
+        if (forType.equals(FunctionalPrimitive.class)) {
+            return PrimitiveTypeConverter.class;
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
- [ x ]: allows users to specify what primitives to use with the `--primitives <symbol>,...` argument. `--listPrimitives` can be used to show all available primitives.
- [ x ]: removes code from the CLI client that wasn't intended to be in the release.